### PR TITLE
Support CREATE OR REPLACE statements

### DIFF
--- a/sql_metadata/keywords_lists.py
+++ b/sql_metadata/keywords_lists.py
@@ -102,6 +102,7 @@ SUPPORTED_QUERY_TYPES = {
     "DELETE": QueryType.DELETE,
     "WITH": QueryType.SELECT,
     "CREATETABLE": QueryType.CREATE,
+    "CREATEORREPLACETABLE": QueryType.CREATE,
     "ALTERTABLE": QueryType.ALTER,
     "DROPTABLE": QueryType.DROP,
 }

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -112,7 +112,7 @@ class Parser:  # pylint: disable=R0902
             )
             .position
         )
-        if tokens[index].normalized in ["CREATE", "ALTER", "DROP"]:
+        if tokens[index].normalized in ["CREATE", "CREATEORREPLACE", "ALTER", "DROP"]:
             switch = tokens[index].normalized + tokens[index + 1].normalized
         else:
             switch = tokens[index].normalized

--- a/test/test_create_table.py
+++ b/test/test_create_table.py
@@ -164,3 +164,22 @@ def test_create_if_not_exists_simple_name():
     assert parser.query_type == QueryType.CREATE
     assert parser.tables == ["analytics_table"]
     assert parser.columns == ["version", "created_date"]
+
+def test_create_or_replace_table_simple():
+    qry = """
+    CREATE OR REPLACE TABLE analytics_table (code INTEGER NOT NULL)
+    """
+    parser = Parser(qry)
+    assert parser.query_type == QueryType.CREATE
+    assert parser.columns == ["code"]
+    assert parser.tables == ["analytics_table"]
+
+def test_create_or_replace_with_select():
+    qry = """
+    CREATE OR REPLACE TABLE mysuper_secret_schema.records AS
+    (SELECT t.id, t.name, e.name as energy FROM t JOIN e ON t.e_id = e.id)
+    """
+    parser = Parser(qry)
+    assert parser.query_type == QueryType.CREATE
+    assert parser.columns == ["t.id", "t.name", "e.name", "t.e_id", "e.id"]
+    assert parser.tables == ["mysuper_secret_schema.records", "t", "e"]


### PR DESCRIPTION
Adds support for CREATE OR REPLACE statements. This will let us resolve INFTY-4 once we update to this newer version of sql-metadata.

There's no CI for our fork of this repro, but I ran the tests locally and all that were passing before my change are still passing along with the new tests.