### PR TITLE
fix handling of empty double quotes

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -964,8 +964,8 @@ class Parser:  # pylint: disable=R0902
         # or digits at the beginning so we only strip them in SQLToken
         # as double quotes are not properly handled in sqlparse
         query = re.sub(r"'.*?'", replace_quotes_in_string, self._raw_query)
-        query = re.sub(r'"([^`]+?)"', r"`\1`", query)
-        query = re.sub(r'"([^`]+?)"\."([^`]+?)"', r"`\1`.`\2`", query)
+        query = re.sub(r'"([^`]*?)"', r"`\1`", query)
+        query = re.sub(r'"([^`]*?)"\."([^`]+?)"', r"`\1`.`\2`", query)
         query = re.sub(r"'.*?'", replace_back_quotes_in_string, query)
 
         return query

--- a/test/test_weird_quoting.py
+++ b/test/test_weird_quoting.py
@@ -1,0 +1,9 @@
+from sql_metadata import Parser
+
+def test_sup850():
+    parser = Parser(
+        """                
+        select coalesce(test_col, "") from dataframe
+        where test_col in ("a")
+        """)
+    assert ["dataframe"] == parser.tables


### PR DESCRIPTION
SUP-850 some evil dialects (like BigQuery) let you use double quotes to delimit strings. `sqlparse` already appears to be handling this properly but this quote handling in `sql-metadata` wasn't handling an empty double-quote delimited string which would break our parsing out of tables for chain SQL and stuff.