### PR TITLE
fix handling of complex identifiers

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -1085,6 +1085,7 @@ class Parser:  # pylint: disable=R0902
                     value=f"{token.tokens[0].normalized}"
                     f"{token.tokens[1].tokens[0].normalized}",
                     ttype=token.tokens[1].tokens[0].ttype,
+                    position=token.tokens[0].position,
                 )
                 new_tok.parent = token.parent
                 yield new_tok

--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -31,8 +31,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
             self._set_default_values()
         else:
             self.value = tok.value.strip("`").strip('"')
-            self.source_position = tok.position
-            self.source_length = tok.length
+            self.source_locations = [(tok.position, tok.position + tok.length)]
             self.is_keyword = tok.is_keyword or (
                 tok.ttype.parent is Name and tok.ttype is not Name
             )
@@ -57,8 +56,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
 
     def _set_default_values(self):
         self.value = ""
-        self.source_position = None
-        self.source_length = None
+        self.source_locations = []
         self.is_keyword = False
         self.is_name = False
         self.is_punctuation = False

--- a/test/test_source_tracking.py
+++ b/test/test_source_tracking.py
@@ -1,0 +1,73 @@
+from sql_metadata import Parser
+from sql_metadata.keywords_lists import TokenType
+
+
+def test_simple_table():
+    source = """
+        SELECT column_1
+        FROM table_1
+    """
+
+    parser = Parser(source)
+    assert ["table_1"] == parser.tables
+    (table_token,) = [
+        token for token in parser.tokens if token.token_type == TokenType.TABLE
+    ]
+    assert len(table_token.source_locations) == 1
+    assert (
+        source[table_token.source_locations[0][0] : table_token.source_locations[0][1]]
+        == "table_1"
+    )
+
+
+def test_complex_identifier():
+    source = """
+        SELECT *
+        FROM "DB".schema."table"
+    """
+
+    parser = Parser(source)
+    assert ["DB.schema.table"] == parser.tables
+    (table_token,) = [
+        token for token in parser.tokens if token.token_type == TokenType.TABLE
+    ]
+    assert len(table_token.source_locations) == 1
+    assert (
+        source[table_token.source_locations[0][0] : table_token.source_locations[0][1]]
+        == '"DB".schema."table"'
+    )
+
+
+def test_whitespace_between_identifiers():
+    source = """
+        SELECT *
+        FROM demo_data
+."demos" .
+  flights
+    """
+
+    parser = Parser(source)
+    assert ["demo_data.demos.flights"] == parser.tables
+    (table_token,) = [
+        token for token in parser.tokens if token.token_type == TokenType.TABLE
+    ]
+    assert len(table_token.source_locations) == 4
+    assert [
+        source[location[0] : location[1]] for location in table_token.source_locations
+    ] == ["demo_data", '."demos"', ".", "flights"]
+
+
+def test_comments_between_identifiers():
+    source = """select from -- wrong
+/* nope */my_db.
+my_schema /* lol */
+.my_table"""
+    parser = Parser(source, filter_comments=True)
+    assert ["my_db.my_schema.my_table"] == parser.tables
+    (table_token,) = [
+        token for token in parser.tokens if token.token_type == TokenType.TABLE
+    ]
+    assert len(table_token.source_locations) == 3
+    assert [
+        source[location[0] : location[1]] for location in table_token.source_locations
+    ] == ["my_db.", "my_schema", ".my_table"]


### PR DESCRIPTION
I was assuming that table tokens could not span multiple lines, but that's not actually true with complex identifiers which are combined from multiple sqlparse tokens. Now tracks potentially multiple source locations to handle this correctly.

Also I realized why we were filtering comments out - because we filter them out when we compile the query so I restored that functionality but behind a flag now so we don't break the test/coverage.