### PR TITLE
first pass at better handling of special duckdb syntax

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -640,8 +640,8 @@ tox = ["tox (<4.5.0)", "virtualenv (<20.22.0)"]
 [package.source]
 type = "git"
 url = "https://github.com/hex-inc/sqlparse"
-reference = "75e26cf8a5dd60d5b3e2b1cb113e3c438f419e10"
-resolved_reference = "75e26cf8a5dd60d5b3e2b1cb113e3c438f419e10"
+reference = "9f598e596e26b630af6480f9beb1b9a89b71ad50"
+resolved_reference = "9f598e596e26b630af6480f9beb1b9a89b71ad50"
 
 [[package]]
 name = "tomli"
@@ -784,4 +784,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "5f1ab8ff11849859f68d0d96b940d1add06ae453d5b808b2fa1f4e93fc6a9120"
+content-hash = "ee60be46679e9a6555b89ad550ddf48e9eb537a5afa60fd0a03e839a512838cd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -640,8 +640,8 @@ tox = ["tox (<4.5.0)", "virtualenv (<20.22.0)"]
 [package.source]
 type = "git"
 url = "https://github.com/hex-inc/sqlparse"
-reference = "9f598e596e26b630af6480f9beb1b9a89b71ad50"
-resolved_reference = "9f598e596e26b630af6480f9beb1b9a89b71ad50"
+reference = "c5cb628991ecf965666435377853c8ba781d3780"
+resolved_reference = "c5cb628991ecf965666435377853c8ba781d3780"
 
 [[package]]
 name = "tomli"
@@ -784,4 +784,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "ee60be46679e9a6555b89ad550ddf48e9eb537a5afa60fd0a03e839a512838cd"
+content-hash = "39a1bedbc031d2b4808c655bafdf5be9def943aeabc0d3730ed502d3d5863b7c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-sqlparse = { git = "https://github.com/hex-inc/sqlparse", rev = "9f598e596e26b630af6480f9beb1b9a89b71ad50" }
+sqlparse = { git = "https://github.com/hex-inc/sqlparse", rev = "c5cb628991ecf965666435377853c8ba781d3780" }
 
 [tool.poetry.dev-dependencies]
 black = "^23.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-# sqlparse = { path = "../sqlparse", develop = true }
 sqlparse = { git = "https://github.com/hex-inc/sqlparse", rev = "9f598e596e26b630af6480f9beb1b9a89b71ad50" }
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-sqlparse = { git = "https://github.com/hex-inc/sqlparse", rev = "75e26cf8a5dd60d5b3e2b1cb113e3c438f419e10" }
+# sqlparse = { path = "../sqlparse", develop = true }
+sqlparse = { git = "https://github.com/hex-inc/sqlparse", rev = "9f598e596e26b630af6480f9beb1b9a89b71ad50" }
 
 [tool.poetry.dev-dependencies]
 black = "^23.9"

--- a/sql_metadata/keywords_lists.py
+++ b/sql_metadata/keywords_lists.py
@@ -31,6 +31,9 @@ TABLE_ADJUSTMENT_KEYWORDS = {
     "INTO",
     "UPDATE",
     "TABLE",
+    "PIVOT",
+    "PIVOT_WIDER",
+    "UNPIVOT",
 }
 
 # next statement beginning after with statement
@@ -105,6 +108,12 @@ SUPPORTED_QUERY_TYPES = {
     "CREATEORREPLACETABLE": QueryType.CREATE,
     "ALTERTABLE": QueryType.ALTER,
     "DROPTABLE": QueryType.DROP,
+    # duckdb FROM-first syntax
+    "FROM": QueryType.SELECT,
+    # duckdb PIVOT/UNPIVOT statements
+    "PIVOT": QueryType.SELECT,
+    "PIVOT_WIDER": QueryType.SELECT,
+    "UNPIVOT": QueryType.SELECT,
 }
 
 # all the keywords we care for - rest is ignored in assigning

--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -264,6 +264,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
             and self.last_keyword_normalized in TABLE_ADJUSTMENT_KEYWORDS
             and self.previous_token.normalized not in ["AS", "WITH"]
             and self.normalized not in ["AS", "SELECT", "IF", "SET", "WITH"]
+            and not self.last_keyword_pivot_operator
         )
 
     @property
@@ -337,6 +338,24 @@ class SQLToken:  # pylint: disable=R0902, R0904
             self.last_keyword_normalized == "INTO"
             and self.previous_token.is_punctuation
         )
+
+    @property
+    def is_pivot_operator(self) -> bool:
+        if self.normalized in {"PIVOT", "UNPIVOT"}:
+            next_token = self.next_token_not_comment
+            return next_token is not None and next_token.is_left_parenthesis
+        else:
+            return False
+
+    @property
+    def last_keyword_pivot_operator(self) -> bool:
+        if self.last_keyword_normalized in {"PIVOT", "UNPIVOT"}:
+            last_keyword_token = self.find_nearest_token(self.last_keyword)
+            return (
+                last_keyword_token is not None and last_keyword_token.is_pivot_operator
+            )
+        else:
+            return False
 
     @property
     def is_potential_alias(self) -> bool:

--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -341,21 +341,25 @@ class SQLToken:  # pylint: disable=R0902, R0904
 
     @property
     def is_pivot_operator(self) -> bool:
+        """
+        Checks if token is the start of a pivot operator
+        """
         if self.normalized in {"PIVOT", "UNPIVOT"}:
             next_token = self.next_token_not_comment
             return next_token is not None and next_token.is_left_parenthesis
-        else:
-            return False
+        return False
 
     @property
     def last_keyword_pivot_operator(self) -> bool:
+        """
+        Checks if last_keyword is pivot/unpivot but is a pivot operator
+        """
         if self.last_keyword_normalized in {"PIVOT", "UNPIVOT"}:
             last_keyword_token = self.find_nearest_token(self.last_keyword)
             return (
                 last_keyword_token is not None and last_keyword_token.is_pivot_operator
             )
-        else:
-            return False
+        return False
 
     @property
     def is_potential_alias(self) -> bool:

--- a/test/test_duckdb.py
+++ b/test/test_duckdb.py
@@ -12,6 +12,13 @@ SELECT *
     parser = Parser(source)
     assert ["monthly_sales"] == parser.tables
 
+def test_table_named_pivot():
+    parser = Parser("from pivot")
+    assert parser.tables == ["pivot"]
+    assert parser.query_type == "SELECT"
+    parser = Parser("select * from pivot join other using (id)")
+    assert "pivot" in parser.tables and "other" in parser.tables
+    assert parser.query_type == "SELECT"
 
 def test_from_first():
     parser = Parser("from dataframe")

--- a/test/test_duckdb.py
+++ b/test/test_duckdb.py
@@ -12,6 +12,7 @@ SELECT *
     parser = Parser(source)
     assert ["monthly_sales"] == parser.tables
 
+
 def test_table_named_pivot():
     parser = Parser("from pivot")
     assert parser.tables == ["pivot"]
@@ -19,6 +20,7 @@ def test_table_named_pivot():
     parser = Parser("select * from pivot join other using (id)")
     assert "pivot" in parser.tables and "other" in parser.tables
     assert parser.query_type == "SELECT"
+
 
 def test_from_first():
     parser = Parser("from dataframe")

--- a/test/test_duckdb.py
+++ b/test/test_duckdb.py
@@ -1,0 +1,113 @@
+from sql_metadata import Parser
+
+
+def test_pivot_operator():
+    source = """
+SELECT *
+  FROM monthly_sales
+    PIVOT(SUM(amount) FOR MONTH IN ('JAN', 'FEB', 'MAR', 'APR'))
+      AS p
+  ORDER BY EMPID
+    """
+    parser = Parser(source)
+    assert ["monthly_sales"] == parser.tables
+
+
+def test_from_first():
+    parser = Parser("from dataframe")
+    assert parser.tables == ["dataframe"]
+    assert parser.query_type == "SELECT"
+    parser = Parser("from dataframe select *")
+    assert parser.tables == ["dataframe"]
+    assert parser.query_type == "SELECT"
+
+    parser = Parser(
+        "from dataframe_1 select * where id in (from dataframe_2 select id)"
+    )
+    assert set(parser.tables) == {"dataframe_1", "dataframe_2"}
+    assert parser.query_type == "SELECT"
+
+
+def test_pivot():
+    parser = Parser(
+        """
+PIVOT
+    vendor_offers_current
+ON 'curr_' || curr
+USING sum(offer_count)
+GROUP BY vendor_id
+"""
+    )
+    assert parser.tables == ["vendor_offers_current"]
+    assert parser.query_type == "SELECT"
+
+    parser = Parser(
+        """
+WITH pivot_alias AS (
+    PIVOT Cities on Year USING SUM(Population) GROUP BY Country
+)
+SELECT * FROM pivot_alias;
+"""
+    )
+    assert parser.tables == ["Cities"]
+    assert parser.query_type == "SELECT"
+
+    parser = Parser(
+        """
+SELECT
+    *
+FROM (
+    PIVOT Cities on Year USING SUM(Population) GROUP BY Country
+) pivot_alias;
+"""
+    )
+    assert "Cities" in parser.tables
+    assert "pivot_alias" not in parser.tables
+    assert parser.query_type == "SELECT"
+
+
+def test_unpivot():
+    parser = Parser(
+        """
+UNPIVOT monthly_sales
+    ON (jan, feb, mar) AS q1, (apr, may, jun) AS q2
+    INTO
+        NAME quarter
+        VALUE month_1_sales, month_2_sales, month_3_sales;
+"""
+    )
+    assert "monthly_sales" in parser.tables
+    assert parser.query_type == "SELECT"
+
+    parser = Parser(
+        """
+WITH unpivot_alias AS (
+    UNPIVOT monthly_sales
+    ON COLUMNS(* EXCLUDE (empid, dept))
+    INTO
+        NAME month
+        VALUE sales
+)
+SELECT * FROM unpivot_alias;
+"""
+    )
+    assert "monthly_sales" in parser.tables
+    assert "unpivot_alias" not in parser.tables
+    assert parser.query_type == "SELECT"
+
+    parser = Parser(
+        """
+SELECT
+    *
+FROM (
+    UNPIVOT monthly_sales
+    ON COLUMNS(* EXCLUDE (empid, dept))
+    INTO
+        NAME month
+        VALUE sales
+) unpivot_alias;
+"""
+    )
+    assert "monthly_sales" in parser.tables
+    assert "unpivot_alias" not in parser.tables
+    assert parser.query_type == "SELECT"


### PR DESCRIPTION
[SUP-1069](https://linear.app/hex/issue/SUP-1069/graph-execution-model-bug-with-sql-cells) this PR pulls in hex-inc/sqlparse#5 and maps these new keywords to the `SELECT` query type since they are all variations of same.